### PR TITLE
Add backend README

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -1,0 +1,100 @@
+# PoliticSystem - Backend
+
+Este diretório contém o projeto **backend** da aplicação, desenvolvido com [Django](https://www.djangoproject.com/). O objetivo principal é disponibilizar uma base para gerenciar usuários e enviar notificações, servindo como ponto de partida para evoluções futuras.
+
+## Estrutura de pastas
+
+```
+core/
+├── core/                # Projeto Django
+│   ├── settings.py      # Configurações do projeto
+│   ├── urls.py          # URLs principais
+│   └── wsgi.py          # Configuração WSGI
+├── manage.py            # Utilitário de linha de comando do Django
+├── notifications/       # Integração com provedores de e-mail (Mailgun)
+├── requirements.txt     # Dependências Python
+├── user/                # Aplicação de usuários
+└── pytest.ini           # Configuração de testes
+```
+
+## Requisitos
+
+- Python 3.11+
+- `pip` para instalação das dependências
+- Opcional: `pre-commit` para verificação automática do código
+
+## Instalação
+
+1. Crie um ambiente virtual e ative-o:
+
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   ```
+
+2. Instale as dependências do projeto:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. (Opcional) Instale os hooks do *pre-commit*:
+
+   ```bash
+   pre-commit install
+   ```
+
+## Variáveis de ambiente
+
+As credenciais utilizadas pelo `MailgunEmailNotifier` são lidas de um arquivo `.env` na raiz do projeto. Crie o arquivo e defina as seguintes variáveis:
+
+```ini
+EMAIL_BASE_URL=https://api.mailgun.net/v3
+SAND_BOX_DOMAIN=sandboxXXXX.mailgun.org
+API_KEY_MAILGUN=sua-chave
+DEFAULT_FROM_EMAIL=no-reply@sandboxXXXX.mailgun.org
+```
+
+Outras configurações do Django podem ser adicionadas nesse arquivo conforme necessidade.
+
+## Banco de dados
+
+O projeto está configurado para usar SQLite por padrão. Para inicializar o banco localmente execute:
+
+```bash
+python manage.py migrate
+```
+
+## Execução
+
+Para iniciar o servidor de desenvolvimento:
+
+```bash
+python manage.py runserver
+```
+
+Se quiser executar as tarefas assíncronas do `django-q` (responsáveis por enviar e-mails de aniversário, por exemplo), utilize:
+
+```bash
+python manage.py qcluster
+```
+
+## Testes
+
+Os testes são executados com `pytest`:
+
+```bash
+pytest
+```
+
+O arquivo `pytest.ini` já define o módulo de configurações do Django e ativa o reuso do banco de dados de testes.
+
+## Contribuição
+
+1. Crie sua *branch* (ex.: `git checkout -b minha-feature`).
+2. Faça suas alterações e garanta que os testes continuam passando.
+3. Envie um *pull request* para revisão.
+
+---
+
+Este projeto é mantido apenas para fins educacionais e serve como exemplo de integração entre Django, `django-q` e Mailgun.


### PR DESCRIPTION
## Summary
- document backend setup and features in `core/README.md`

## Testing
- `pre-commit run --files core/README.md`
- `pytest -q` *(fails: ImportError: cannot import name 'baseconv' from 'django.utils')*

------
https://chatgpt.com/codex/tasks/task_e_6853a4bebf3c83219b16858c6ad90822

## Resumo por Sourcery

Adiciona um README abrangente para o backend, descrevendo a estrutura do projeto, etapas de configuração, variáveis de ambiente, inicialização do banco de dados, comandos de execução, instruções de teste e diretrizes de contribuição

Documentação:
- Documenta a estrutura do projeto backend e as dependências em core/README.md
- Descreve as etapas de instalação, incluindo a configuração do ambiente virtual e a instalação de dependências
- Detalha a configuração das variáveis de ambiente para a integração do Mailgun
- Explica a migração do banco de dados, o servidor de desenvolvimento e a execução de tarefas assíncronas
- Descreve o processo de teste com pytest e hooks pre-commit
- Fornece o fluxo de trabalho de contribuição e o contexto do projeto para fins educacionais

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a comprehensive README for the backend, outlining project structure, setup steps, environment variables, database initialization, execution commands, testing instructions, and contribution guidelines

Documentation:
- Document backend project structure and dependencies in core/README.md
- Outline installation steps including virtual environment setup and dependency installation
- Detail environment variable configuration for Mailgun integration
- Explain database migration, development server, and asynchronous task execution
- Describe testing process with pytest and pre-commit hooks
- Provide contribution workflow and project context for educational purposes

</details>